### PR TITLE
Add postgresql-client to installed packages

### DIFF
--- a/web/v2.6.3/Dockerfile
+++ b/web/v2.6.3/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update && apt-get install -y \
     npm \
     optipng \
     pngquant \
+    postgresql-client \
     vim
 RUN npm install -g svgo
 RUN bundle config set path vendor/bundle/ && bundle install


### PR DESCRIPTION
This package provides the `psql` command, which is required by Discourse for creating/restoring backups.